### PR TITLE
Fix for xextool execution under mono runtime

### DIFF
--- a/Chilano/Iso2God/Program.cs
+++ b/Chilano/Iso2God/Program.cs
@@ -25,7 +25,9 @@ namespace Chilano.Iso2God
                 String destinationPath = arguments[2];
 
                 Console.WriteLine("+ Computing ISO metadata ...");                
-                IsoDetails iso = new IsoDetails(new IsoDetailsArgs(isoPath, Path.GetTempPath(), Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar + "xextool.exe"));
+                bool IsRunningOnMono = (Type.GetType ("Mono.Runtime") != null);
+		String xexToolExecutable = IsRunningOnMono ? "mono xextool.exe" : "xextool.exe";
+		IsoDetails iso = new IsoDetails(new IsoDetailsArgs(isoPath, Path.GetTempPath(), Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar + xexToolExecutable));
                 IsoDetailsResults isoDetailsResults = iso.IsoDetails_DoWork();
                 IsoEntryID isoEntryID = new IsoEntryID(isoDetailsResults.TitleID, isoDetailsResults.MediaID, Convert.ToByte(isoDetailsResults.DiscNumber[0]), Convert.ToByte(isoDetailsResults.DiscCount[0]), Convert.ToByte(isoDetailsResults.Platform[0]), Convert.ToByte(isoDetailsResults.ExType[0]));
                 IsoEntry isoEntry = new IsoEntry(IsoEntryPlatform.Xbox360, isoPath, destinationPath, new FileInfo(isoPath).Length, isoDetailsResults.Name, isoEntryID);

--- a/Chilano/Iso2God/Program.cs
+++ b/Chilano/Iso2God/Program.cs
@@ -26,8 +26,8 @@ namespace Chilano.Iso2God
 
                 Console.WriteLine("+ Computing ISO metadata ...");                
                 bool IsRunningOnMono = (Type.GetType ("Mono.Runtime") != null);
-		String xexToolExecutable = IsRunningOnMono ? "mono xextool.exe" : "xextool.exe";
-		IsoDetails iso = new IsoDetails(new IsoDetailsArgs(isoPath, Path.GetTempPath(), Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar + xexToolExecutable));
+                String xexToolExecutable = IsRunningOnMono ? "mono xextool.exe" : "xextool.exe";
+                IsoDetails iso = new IsoDetails(new IsoDetailsArgs(isoPath, Path.GetTempPath(), Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar + xexToolExecutable));
                 IsoDetailsResults isoDetailsResults = iso.IsoDetails_DoWork();
                 IsoEntryID isoEntryID = new IsoEntryID(isoDetailsResults.TitleID, isoDetailsResults.MediaID, Convert.ToByte(isoDetailsResults.DiscNumber[0]), Convert.ToByte(isoDetailsResults.DiscCount[0]), Convert.ToByte(isoDetailsResults.Platform[0]), Convert.ToByte(isoDetailsResults.ExType[0]));
                 IsoEntry isoEntry = new IsoEntry(IsoEntryPlatform.Xbox360, isoPath, destinationPath, new FileInfo(isoPath).Length, isoDetailsResults.Name, isoEntryID);


### PR DESCRIPTION
Fixed failure of xextool execution on mono under linux. 
